### PR TITLE
Map async JS methods to Kotlin suspend functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ A JS value can be evaluated via:
 - `JsValue.evaluateBlocking<T>()`  // blocking
 - `JsValue.evaluateBlocking(Class<*> javaClass)`  // from Java
 
-A JS function can be [mapped to a Kotlin proxy function](#calling-js-functions-from-kotlin) via `JsValue.mapToNativeObject()`.
-A JS object can be [mapped to a Java/Kotlin proxy object](#using-js-objects-from-javakotlin) via `JsValue.mapToNativeObject()`.
+A JS function can be [mapped to a Kotlin proxy function](#3-calling-js-functions-from-kotlin) via `JsValue.mapToNativeObject()`.
+A JS object can be [mapped to a Java/Kotlin proxy object](#5-using-js-objects-from-javakotlin) via `JsValue.mapToNativeObject()`.
 
 
 ### 3. Calling JS functions from Kotlin

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,14 +1,11 @@
 Features:
-- JS Api with suspending functions
-- implement varargs for QuickJS
 - pure Kotlin version of console (.log, .warn, ...) with
   * varargs JsonObjectWrapper (debug)
   * varargs String (release)
 - test exceptions:
   * array too large (how?)
-  * JS exception stack with line number (done)
-  * null pointer exceptions (done)
 - JsValue.fromNativeValue<T: Any?>(v: T)
+- Support for @Serializable objects
 - Small app for performance tests
 
 Performance:

--- a/jsbridge/src/main/jni/JavaScriptMethod.h
+++ b/jsbridge/src/main/jni/JavaScriptMethod.h
@@ -56,7 +56,6 @@ private:
   std::unique_ptr<const JavaType> m_returnValueType;
   JniGlobalRef<jsBridgeParameter> m_returnValueParameter;
   std::vector<std::unique_ptr<const JavaType>> m_argumentTypes;
-  bool m_isVarArgs;
   bool m_isLambda;
 };
 

--- a/jsbridge/src/main/jni/JavaScriptObject.cpp
+++ b/jsbridge/src/main/jni/JavaScriptObject.cpp
@@ -98,7 +98,7 @@ JavaScriptObject::JavaScriptObject(const JsBridgeContext *jsBridgeContext, std::
   duk_pop(ctx);  // JS object
 }
 
-JValue JavaScriptObject::call(const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args) const {
+JValue JavaScriptObject::call(const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args, bool awaitJsPromise) const {
 
   assert(m_jsHeapPtr != nullptr);
 
@@ -122,7 +122,7 @@ JValue JavaScriptObject::call(const JniLocalRef<jobject> &javaMethod, const JObj
 
     // Method found -> call it
     const auto &jsMethod = methodIt->second;
-    return jsMethod->invoke(m_jsBridgeContext, m_jsHeapPtr, args, false);
+    return jsMethod->invoke(m_jsBridgeContext, m_jsHeapPtr, args, awaitJsPromise);
   } catch (const std::runtime_error &e) {
     std::string strError("Error while calling JS method " + m_name + "." + getMethodName() + ": " + e.what());
     throw std::runtime_error(strError);
@@ -184,7 +184,7 @@ JavaScriptObject::JavaScriptObject(const JsBridgeContext *jsBridgeContext, std::
   }
 }
 
-JValue JavaScriptObject::call(JSValueConst jsObjectValue, const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args) const {
+JValue JavaScriptObject::call(JSValueConst jsObjectValue, const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args, bool awaitJsPromise) const {
 
   JSContext *ctx = m_jsBridgeContext->getQuickJsContext();
   const JniContext *jniContext = m_jsBridgeContext->getJniContext();
@@ -217,7 +217,7 @@ JValue JavaScriptObject::call(JSValueConst jsObjectValue, const JniLocalRef<jobj
   //  throw std::invalid_argument("Error while calling JS method: " + m_name + " is not a valid JS function!");
   //}
 
-  return jsMethod->invoke(m_jsBridgeContext, jsMethodValue, jsObjectValue, args, false);
+  return jsMethod->invoke(m_jsBridgeContext, jsMethodValue, jsObjectValue, args, awaitJsPromise);
 }
 
 #endif

--- a/jsbridge/src/main/jni/JavaScriptObject.h
+++ b/jsbridge/src/main/jni/JavaScriptObject.h
@@ -47,11 +47,11 @@ public:
 #if defined(DUKTAPE)
   JavaScriptObject(const JsBridgeContext *, std::string strName, duk_idx_t jsObjectIndex, const JObjectArrayLocalRef &methods, bool check);
 
-  JValue call(const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args) const;
+  JValue call(const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args, bool awaitJsPromise) const;
 #elif defined(QUICKJS)
   JavaScriptObject(const JsBridgeContext *, std::string strName, JSValueConst jsObjectValue, const JObjectArrayLocalRef &methods, bool check);
 
-  JValue call(JSValueConst jsObjectValue, const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args) const;
+  JValue call(JSValueConst jsObjectValue, const JniLocalRef<jobject> &javaMethod, const JObjectArrayLocalRef &args, bool awaitJsPromise) const;
 #endif
 
   JavaScriptObject() = delete;

--- a/jsbridge/src/main/jni/JsBridgeContext.h
+++ b/jsbridge/src/main/jni/JsBridgeContext.h
@@ -66,7 +66,7 @@ public:
   void registerJsObject(const std::string &strName, const JObjectArrayLocalRef &methods, bool check);
   void registerJsLambda(const std::string &strName, const JniLocalRef<jsBridgeMethod> &method);
   JValue callJsMethod(const std::string &objectName, const JniLocalRef<jobject> &javaMethod,
-                              const JObjectArrayLocalRef &args);
+                              const JObjectArrayLocalRef &args, bool awaitJsPromise);
   JValue callJsLambda(const std::string &strFunctionName, const JObjectArrayLocalRef &args,
                               bool awaitJsPromise);
 

--- a/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
+++ b/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
@@ -308,7 +308,8 @@ void JsBridgeContext::registerJsLambda(const std::string &strName,
 
 JValue JsBridgeContext::callJsMethod(const std::string &objectName,
                                      const JniLocalRef<jobject> &javaMethod,
-                                     const JObjectArrayLocalRef &args) {
+                                     const JObjectArrayLocalRef &args,
+                                     bool awaitJsPromise) {
   CHECK_STACK(m_ctx);
 
   // Get the JS object
@@ -327,7 +328,7 @@ JValue JsBridgeContext::callJsMethod(const std::string &objectName,
   }
 
   duk_pop(m_ctx);
-  return cppJsObject->call(javaMethod, args);
+  return cppJsObject->call(javaMethod, args, awaitJsPromise);
 }
 
 JValue JsBridgeContext::callJsLambda(const std::string &strFunctionName,

--- a/jsbridge/src/main/jni/JsBridgeContext_quickjs.cpp
+++ b/jsbridge/src/main/jni/JsBridgeContext_quickjs.cpp
@@ -230,7 +230,8 @@ void JsBridgeContext::registerJsLambda(const std::string &strName,
 
 JValue JsBridgeContext::callJsMethod(const std::string &objectName,
                                      const JniLocalRef<jobject> &javaMethod,
-                                     const JObjectArrayLocalRef &args) {
+                                     const JObjectArrayLocalRef &args,
+                                     bool awaitJsPromise) {
 
   // Get the JS object
   JSValue globalObj = JS_GetGlobalObject(m_ctx);
@@ -250,7 +251,7 @@ JValue JsBridgeContext::callJsMethod(const std::string &objectName,
                                 " because it does not exist or has been deleted!");
   }
 
-  return cppJsObject->call(jsObjectValue, javaMethod, args);
+  return cppJsObject->call(jsObjectValue, javaMethod, args, awaitJsPromise);
 }
 
 JValue JsBridgeContext::callJsLambda(const std::string &strFunctionName,

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
@@ -205,7 +205,7 @@ JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniRe
 }
 
 JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniCallJsMethod
-    (JNIEnv *env, jobject, jlong lctx, jstring objectName, jobject javaMethod, jobjectArray args) {
+    (JNIEnv *env, jobject, jlong lctx, jstring objectName, jobject javaMethod, jobjectArray args, jboolean awaitJsPromise) {
 
   //alog("jniCallJsMethod()");
 
@@ -219,7 +219,8 @@ JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jn
   try {
     value = jsBridgeContext->callJsMethod(strObjectName,
                                           JniLocalRef<jobject>(jniContext, javaMethod, JniLocalRefMode::Borrowed),
-                                          JObjectArrayLocalRef(jniContext, args, JniLocalRefMode::Borrowed));
+                                          JObjectArrayLocalRef(jniContext, args, JniLocalRefMode::Borrowed),
+                                          awaitJsPromise);
   } catch (const std::exception &e) {
     jsBridgeContext->getExceptionHandler()->jniThrow(e);
   }

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
@@ -56,7 +56,7 @@ JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniRe
     (JNIEnv *, jobject, jlong, jstring, jobject);
 
 JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniCallJsMethod
-    (JNIEnv *, jobject, jlong, jstring, jobject, jobjectArray);
+    (JNIEnv *, jobject, jlong, jstring, jobject, jobjectArray, jboolean awaitJsPromise);
 
 JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniCallJsLambda
     (JNIEnv *, jobject, jlong, jstring, jobjectArray, jboolean);


### PR DESCRIPTION
Use case:

Kotlin code:
```
interface JsApi: NativeToJsInterface {
  suspend fun calcSum(a: Int, b: Int): Int
}
```

JS code:
```
const api = {
    calcSum: async (a, b) => a + b
    // OR: calcSumPromise: (a, b) => new Promise(resolve => a + b)
}
```