### PR TITLE
Handle undefined, null, number as string in `setTimeout/setInterval`

### DIFF
--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/FeatureTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/FeatureTest.kt
@@ -1,0 +1,17 @@
+package de.prosiebensat1digital.oasisjsbridge
+
+/**
+ * Android gradle plugin does not support JUnit @Category annotation by default,
+ * so here is another way to group/scope tests by features:
+ *
+ * 1. Add custom annotation to your test methods.
+ * 2. Update run config:
+ *   Run -> Edit Configuration -> Android Instrumentation Tests -> Instrumentation Arguments
+ *   name: annotation
+ *   value: de.prosiebensat1digital.oasisjsbridge.Feature_SetTimeout
+ *
+ * 3. Run the tests with this config, JUnit will only run annotated tests
+ *
+ * see https://stackoverflow.com/a/38676843/1237733
+ */
+annotation class Feature_SetTimeout()

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -2018,7 +2018,7 @@ class JsBridgeTest {
                 clearInterval(timeoutId);
               }
               i++;
-            }, null);
+            }, undefined);
         """
 
         subject.evaluateNoRetVal(js)

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -1820,6 +1820,35 @@ class JsBridgeTest {
 
     @Test
     @Feature_SetTimeout
+    fun testSetTimeoutWithArgsAndStringNumberTimeout() {
+        // GIVEN
+        val subject = createAndSetUpJsBridge()
+        val jsExpectations = JsExpectations()
+        val jsExpectationsJsValue = JsValue.fromNativeObject(subject, jsExpectations)
+
+        // WHEN
+        val js = """
+            setTimeout(function(a, b, c) {
+                $jsExpectationsJsValue.addExpectation("a", a);
+                $jsExpectationsJsValue.addExpectation("b", b);
+                $jsExpectationsJsValue.addExpectation("c", c);
+            }, "100", "aString", null, 69);
+        """.trimIndent()
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { delay(1000); waitForDone(subject) }
+
+        // THEN
+        jsExpectations.checkEquals("a", "aString")
+        jsExpectations.checkEquals("b", JsonObjectWrapper("null"))
+        jsExpectations.checkEquals("c", 69)
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
     fun testSetTimeoutWithArgsAndWrongTypeTimeout() {
         // GIVEN
         val subject = createAndSetUpJsBridge()
@@ -2032,6 +2061,48 @@ class JsBridgeTest {
               }
               i++;
             }, "not_a_number_is_zero_timeout");
+        """
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { waitForDone(subject) }
+
+        // THEN
+        // Note: mockk verify with ordering currently has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(ordering = Ordering.SEQUENCE, timeout = 1000) {
+                jsToNativeFunctionMock(eq("interval1"))
+                jsToNativeFunctionMock(eq("interval2"))
+                jsToNativeFunctionMock(eq("interval3"))
+            }
+        }
+
+        // Stop *after* interval3
+        // Note: mockk verify with timeout has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(inverse = true, timeout = 1000) { jsToNativeFunctionMock(eq("interval4")) }
+        }
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetAndClearIntervalWithStringNumberTimeout() {
+        val subject = createAndSetUpJsBridge()
+
+        // WHEN
+        val js = """
+            var i = 1;
+            var timeoutId = null;
+            timeoutId = setInterval(function() {
+              console.log("Inside interval");
+              nativeFunctionMock("interval" + i);
+              if (i == 3) {
+                clearInterval(timeoutId);
+              }
+              i++;
+            }, "100");
         """
 
         subject.evaluateNoRetVal(js)

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -1696,6 +1696,7 @@ class JsBridgeTest {
     }
 
     @Test
+    @Feature_SetTimeout
     fun testSetTimeout() {
         // GIVEN
         val initialDelay = 500L
@@ -1731,6 +1732,7 @@ class JsBridgeTest {
     }
 
     @Test
+    @Feature_SetTimeout
     fun testSetTimeoutWithArgs() {
         // GIVEN
         val subject = createAndSetUpJsBridge()
@@ -1759,6 +1761,94 @@ class JsBridgeTest {
     }
 
     @Test
+    @Feature_SetTimeout
+    fun testSetTimeoutWithArgsAndNullTimeout() {
+        // GIVEN
+        val subject = createAndSetUpJsBridge()
+        val jsExpectations = JsExpectations()
+        val jsExpectationsJsValue = JsValue.fromNativeObject(subject, jsExpectations)
+
+        // WHEN
+        val js = """
+            setTimeout(function(a, b, c) {
+                $jsExpectationsJsValue.addExpectation("a", a);
+                $jsExpectationsJsValue.addExpectation("b", b);
+                $jsExpectationsJsValue.addExpectation("c", c);
+            }, null, "aString", null, 69);
+        """.trimIndent()
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { delay(1000); waitForDone(subject) }
+
+        // THEN
+        jsExpectations.checkEquals("a", "aString")
+        jsExpectations.checkEquals("b", JsonObjectWrapper("null"))
+        jsExpectations.checkEquals("c", 69)
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetTimeoutWithArgsAndUndefinedTimeout() {
+        // GIVEN
+        val subject = createAndSetUpJsBridge()
+        val jsExpectations = JsExpectations()
+        val jsExpectationsJsValue = JsValue.fromNativeObject(subject, jsExpectations)
+
+        // WHEN
+        val js = """
+            setTimeout(function(a, b, c) {
+                $jsExpectationsJsValue.addExpectation("a", a);
+                $jsExpectationsJsValue.addExpectation("b", b);
+                $jsExpectationsJsValue.addExpectation("c", c);
+            }, undefined, "aString", null, 69);
+        """.trimIndent()
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { delay(1000); waitForDone(subject) }
+
+        // THEN
+        jsExpectations.checkEquals("a", "aString")
+        jsExpectations.checkEquals("b", JsonObjectWrapper("null"))
+        jsExpectations.checkEquals("c", 69)
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetTimeoutWithArgsAndWrongTypeTimeout() {
+        // GIVEN
+        val subject = createAndSetUpJsBridge()
+        val jsExpectations = JsExpectations()
+        val jsExpectationsJsValue = JsValue.fromNativeObject(subject, jsExpectations)
+
+        // WHEN
+        val js = """
+            setTimeout(function(a, b, c) {
+                $jsExpectationsJsValue.addExpectation("a", a);
+                $jsExpectationsJsValue.addExpectation("b", b);
+                $jsExpectationsJsValue.addExpectation("c", c);
+            }, "not_a_number_is_zero_timeout", "aString", null, 69);
+        """.trimIndent()
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { delay(1000); waitForDone(subject) }
+
+        // THEN
+        jsExpectations.checkEquals("a", "aString")
+        jsExpectations.checkEquals("b", JsonObjectWrapper("null"))
+        jsExpectations.checkEquals("c", 69)
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
     fun testClearTimeout() {
         val events = mutableListOf<String>()
 
@@ -1800,6 +1890,7 @@ class JsBridgeTest {
     }
 
     @Test
+    @Feature_SetTimeout
     fun testSetAndClearInterval() {
         val subject = createAndSetUpJsBridge()
 
@@ -1815,6 +1906,132 @@ class JsBridgeTest {
               }
               i++;
             }, 50);
+        """
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { waitForDone(subject) }
+
+        // THEN
+        // Note: mockk verify with ordering currently has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(ordering = Ordering.SEQUENCE, timeout = 1000) {
+                jsToNativeFunctionMock(eq("interval1"))
+                jsToNativeFunctionMock(eq("interval2"))
+                jsToNativeFunctionMock(eq("interval3"))
+            }
+        }
+
+        // Stop *after* interval3
+        // Note: mockk verify with timeout has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(inverse = true, timeout = 1000) { jsToNativeFunctionMock(eq("interval4")) }
+        }
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetAndClearIntervalWithNullTimeout() {
+        val subject = createAndSetUpJsBridge()
+
+        // WHEN
+        val js = """
+            var i = 1;
+            var timeoutId = null;
+            timeoutId = setInterval(function() {
+              console.log("Inside interval");
+              nativeFunctionMock("interval" + i);
+              if (i == 3) {
+                clearInterval(timeoutId);
+              }
+              i++;
+            }, null);
+        """
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { waitForDone(subject) }
+
+        // THEN
+        // Note: mockk verify with ordering currently has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(ordering = Ordering.SEQUENCE, timeout = 1000) {
+                jsToNativeFunctionMock(eq("interval1"))
+                jsToNativeFunctionMock(eq("interval2"))
+                jsToNativeFunctionMock(eq("interval3"))
+            }
+        }
+
+        // Stop *after* interval3
+        // Note: mockk verify with timeout has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(inverse = true, timeout = 1000) { jsToNativeFunctionMock(eq("interval4")) }
+        }
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetAndClearIntervalWithUndefinedTimeout() {
+        val subject = createAndSetUpJsBridge()
+
+        // WHEN
+        val js = """
+            var i = 1;
+            var timeoutId = null;
+            timeoutId = setInterval(function() {
+              console.log("Inside interval");
+              nativeFunctionMock("interval" + i);
+              if (i == 3) {
+                clearInterval(timeoutId);
+              }
+              i++;
+            }, null);
+        """
+
+        subject.evaluateNoRetVal(js)
+
+        runBlocking { waitForDone(subject) }
+
+        // THEN
+        // Note: mockk verify with ordering currently has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(ordering = Ordering.SEQUENCE, timeout = 1000) {
+                jsToNativeFunctionMock(eq("interval1"))
+                jsToNativeFunctionMock(eq("interval2"))
+                jsToNativeFunctionMock(eq("interval3"))
+            }
+        }
+
+        // Stop *after* interval3
+        // Note: mockk verify with timeout has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(inverse = true, timeout = 1000) { jsToNativeFunctionMock(eq("interval4")) }
+        }
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    @Feature_SetTimeout
+    fun testSetAndClearIntervalWithWrongTypeTimeout() {
+        val subject = createAndSetUpJsBridge()
+
+        // WHEN
+        val js = """
+            var i = 1;
+            var timeoutId = null;
+            timeoutId = setInterval(function() {
+              console.log("Inside interval");
+              nativeFunctionMock("interval" + i);
+              if (i == 3) {
+                clearInterval(timeoutId);
+              }
+              i++;
+            }, "not_a_number_is_zero_timeout");
         """
 
         subject.evaluateNoRetVal(js)

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/SetTimeoutExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/SetTimeoutExtension.kt
@@ -32,9 +32,12 @@ internal class SetTimeoutExtension(private val jsBridge: JsBridge) {
         // As setTimeout(cb, ms, args...) can also receive arguments passed to the given callback,
         // we need to convert them to an array and wrap the callback lambda
         JsValue.newFunction(jsBridge, "cb", "msecs", """
-            // undefined, null and wrong variable type (e.g. string) are also valid values for timeout == no delay
-            if (typeof msecs != 'number') {
-              msecs = 0;
+            // undefined, null and wrong variable type (e.g. string) are valid values for timeout == no delay
+            // "1000" string is converted into a number
+            const TIMEOUT_MAX = 2 ** 31 - 1;
+            msecs *= 1; // Coalesce to number or NaN
+            if (!(msecs >= 1 && msecs <= TIMEOUT_MAX)) {
+                msecs = 0;
             }
             var argArray = [].slice.call(arguments, 2);
             var cbWrapper = function() {
@@ -49,9 +52,12 @@ internal class SetTimeoutExtension(private val jsBridge: JsBridge) {
 
         // Same as for setTimeout but with setTimeoutHelper repeat parameter set to true
         JsValue.newFunction(jsBridge, "cb", "msecs", """
-            // undefined, null and wrong variable type (e.g. string) are also valid values for timeout == no delay
-            if (typeof msecs != 'number') {
-              msecs = 0;
+            // undefined, null and wrong variable type (e.g. string) are valid values for timeout == no delay
+            // "1000" string is converted into a number
+            const TIMEOUT_MAX = 2 ** 31 - 1;
+            msecs *= 1; // Coalesce to number or NaN
+            if (!(msecs >= 1 && msecs <= TIMEOUT_MAX)) {
+                msecs = 0;
             }
             var argArray = [].slice.call(arguments, 2);
             var cbWrapper = function() {

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/SetTimeoutExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/SetTimeoutExtension.kt
@@ -32,6 +32,10 @@ internal class SetTimeoutExtension(private val jsBridge: JsBridge) {
         // As setTimeout(cb, ms, args...) can also receive arguments passed to the given callback,
         // we need to convert them to an array and wrap the callback lambda
         JsValue.newFunction(jsBridge, "cb", "msecs", """
+            // undefined, null and wrong variable type (e.g. string) are also valid values for timeout == no delay
+            if (typeof msecs != 'number') {
+              msecs = 0;
+            }
             var argArray = [].slice.call(arguments, 2);
             var cbWrapper = function() {
               cb.apply(null, argArray);
@@ -45,6 +49,10 @@ internal class SetTimeoutExtension(private val jsBridge: JsBridge) {
 
         // Same as for setTimeout but with setTimeoutHelper repeat parameter set to true
         JsValue.newFunction(jsBridge, "cb", "msecs", """
+            // undefined, null and wrong variable type (e.g. string) are also valid values for timeout == no delay
+            if (typeof msecs != 'number') {
+              msecs = 0;
+            }
             var argArray = [].slice.call(arguments, 2);
             var cbWrapper = function() {
               cb.apply(null, argArray);


### PR DESCRIPTION
**Actual Result:**
Passing undefined, null, string or number as string to `setTimeout/setInterval` as timeout crashes the jsbridge

**Expected Result:**
Passing undefined, null or string results in 0 msecs timeout. Passing number as string converts it to a number and applies as timeout