### PR TITLE
Fixed the OkHttp empty body exception

### DIFF
--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
@@ -78,7 +78,7 @@ internal class XMLHttpRequestExtension(
                     }
                 }
 
-                // Add user argent header if not set
+                // Add user agent header if not set
                 if (requestHeadersBuilder["user-agent"] == null) {
                     config.userAgent?.let { requestHeadersBuilder.add("User-Agent", it) }
                 }
@@ -86,9 +86,7 @@ internal class XMLHttpRequestExtension(
 
                 // Request body
                 val contentType = requestHeaders["content-type"] ?: ""
-                val requestBody = data?.let {
-                    data.toRequestBody(contentType.toMediaTypeOrNull())
-                }
+                val requestBody = safeRequestBody(data, contentType)
 
                 Timber.d("Performing XHR request (query: $url)...")
 
@@ -141,6 +139,9 @@ internal class XMLHttpRequestExtension(
             }
         }
     }
+
+    private fun safeRequestBody(data : String?, contentType: String): RequestBody =
+        data?.toRequestBody(contentType.toMediaTypeOrNull()) ?: "".toRequestBody(contentType.toMediaTypeOrNull())
 }
 
 /*


### PR DESCRIPTION
Issue: JS-Side wants to send the POST request, so in order to do so, we provide them with OkHttp client. Yet, the issue appears to be quite annoying, therefore here's the fix.

The OkHttp claims that sending a post-request with empty body is an error, therefore they throw an exception. It is now considered and replaced with empty body in case when the JS wants to send empty body request.

Here's the link to the existing thread in OkHttp library and the comment where they proposed to do the empty request body approach: [Magic Link](https://github.com/square/okhttp/issues/751#issuecomment-182440925)

Also fixed a small typo :)
