### PR TITLE
 Make AIDL interface instances reusable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     #- tags:
   pull_request:
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+
 jobs:
   jvm:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx4096m 
+org.gradle.jvmargs=-Xmx4g
 android.useAndroidX=true
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -264,7 +264,6 @@ constructor(config: JsBridgeConfig): CoroutineScope {
                 Timber.d("-> $filename ($jsFileName) has been successfully evaluated!")
             } catch (t: Throwable) {
                 throw JsFileEvaluationError(filename, t)
-                    .also(::notifyErrorListeners)
             }
 
             processPromiseQueue()
@@ -281,7 +280,6 @@ constructor(config: JsBridgeConfig): CoroutineScope {
                 Timber.d("-> file content ($filename) has been successfully evaluated!")
             } catch (t: Throwable) {
                 throw JsFileEvaluationError(filename, t)
-                    .also(::notifyErrorListeners)
             }
 
             processPromiseQueue()
@@ -939,8 +937,7 @@ constructor(config: JsBridgeConfig): CoroutineScope {
                     val jniJsContext = jniJsContextOrThrow()
                     jniCallJsLambda(jniJsContext, jsFunctionObject.associatedJsName, args, false)
                 } catch (t: Throwable) {
-                    JsToNativeFunctionCallError("JS lambda($globalObjectName)", t )
-                        .also(::notifyErrorListeners)
+                    throw JsToNativeFunctionCallError("JS lambda($globalObjectName)", t )
                 }
             }
         }
@@ -1036,7 +1033,6 @@ constructor(config: JsBridgeConfig): CoroutineScope {
         if (!isJsThread()) {
             Timber.e("checkJsThread() - FAILED!")
             throw InternalError(Throwable("Unexpected call: should be in the JsThread but is in ${Thread.currentThread().name}"))
-                .also(::notifyErrorListeners)
         }
     }
 
@@ -1117,7 +1113,6 @@ constructor(config: JsBridgeConfig): CoroutineScope {
                     callJsMethod(jsValue.associatedJsName, method, args ?: arrayOf(), false)
                 } catch (t: Throwable) {
                     throw NativeToJsCallError("${type.canonicalName}/$jsValue.${method.name}", t)
-                        .also(::notifyErrorListeners)
                 }
             }
         }


### PR DESCRIPTION
- When an AIDL interface is sent from JS to native (e.g. a callback object), remember in JS which Java instance is used
- When sending the same JS instance again, also use the same Java instance

This makes it possible for example to register/unregister callbacks:
  var cb = { ... };
  javaObject.register(cb);
  javaObject.unregister(cb);

Additionally: update dependencies, remove double error notifications