### PR TITLE
Evaluate file as module and small API adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,19 @@ implementation "de.prosiebensat1digital.oasis-jsbridge-android:oasis-jsbridge-qu
 
 ### Evaluating JS code
 
-Without return value:
+Unsync calls (will be evaluated synchronously):
 ```kotlin
-jsBridge.evaluateNoRetVal("console.log('hello');")
-jsBridge.evaluateLocalFile(context, "js/file.js")  // Android asset
+jsBridge.evaluateUnsync("console.log('hello');")
+jsBridge.evaluateFileContentUnsync("console.log('hello')", "js/test.js")
 ```
 
-With return value:
+Suspending calls:
 ```kotlin
+// Without return value:
+jsBridge.evaluate<Unit>("console.log('hello');")
+jsBridge.evaluateFileContent("console.log('hello')", "js/test.js")
+
+// With return value:
 val sum: Int = jsBridge.evaluate("1+2")  // suspending call
 val sum: Int = jsBridge.evaluate("new Promise(function(resolve) { resolve(1+2); })")  // suspending call (JS promise)
 val msg: String = jsBridge.evaluate("'message'.toUpperCase()")  // suspending call
@@ -374,7 +379,7 @@ val nativeApi = object: NativeApi {
 Bridging JavaScript and Kotlin:
 ```kotlin
 val jsBridge = JsBridge(JsBridgeConfig.standardConfig())
-jsBridge.evaluateLocalFile(context, "js/api.js")
+jsBridge.evaluateLocalFileUnsync(context, "js/api.js")
 
 // JS "proxy" to native API
 val nativeApiJsValue = JsValue.fromNativeObject(jsBridge, nativeApi)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ implementation "de.prosiebensat1digital.oasis-jsbridge-android:oasis-jsbridge-qu
 1. [Map JS functions to Kotlin](#calling-js-functions-from-kotlin)
 1. [Map Kotlin functions to JS](#calling-kotlin-functions-from-js)
 1. [Map JS objects to AIDL](#using-aidl-from-js)
+1. [ES6 modules](#es6-modules)
 1. [Extensions](#extensions)
 
 
@@ -258,6 +259,24 @@ val aidlJsValue = JsValue.fromAidlInterface(jsBridge, aidlInterface)
 
 // Call an AIDL method from JS
 jsBridge.evaluateUnsync("""$aidlJsValue.aidlMethod({parcelableField1: 1, parcelableField2: "two"});""")
+```
+
+### ES6 modules
+
+ES6 modules are fully supported on QuickJS. This is done by:
+
+- Evaluating files as modules:
+
+Example:
+```
+jsBridge.evaluateLocalFile(context, "js/module.js", false, JsBridge.JsFileEvaluationType.Module)
+```
+
+- Defining a custom module loader which is triggered as needed to get the JS code of a given module:
+
+Example:
+```
+jsBridge.setJsModuleLoader { moduleName -> "<module_content>" }
 ```
 
 ### Extensions

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ val obj = object : NativeApi {
 val nativeApi: JsValue = JsValue.fromNativeObject(jsBridge, obj)
 
 // Call native method from JS
-jsBridge.evaluateNoRetVal("globalThis.x = $nativeApi.method(1, 'two');")
+jsBridge.evaluateUnsync("globalThis.x = $nativeApi.method(1, 'two');")
 ```
 
 See [Example](#example-consuming-a-js-api-from-kotlin).
@@ -237,7 +237,7 @@ Available methods:
 ```kotlin
 val calcSumNative = JsValue.fromNativeFunction2(jsBridge) { a: Int, b: Int -> a + b }
 
-jsBridge.evaluateNoRetVal("console.log('Sum is', $calcSumNative(1, 2))");
+jsBridge.evaluateUnsync("console.log('Sum is', $calcSumNative(1, 2))");
 ```
 
 Note: the native function is triggered from the "JS" thread
@@ -257,7 +257,7 @@ To map an AIDL interface to JS:
 val aidlJsValue = JsValue.fromAidlInterface(jsBridge, aidlInterface)
 
 // Call an AIDL method from JS
-jsBridge.evaluateNoRetVal("""$aidlJsValue.aidlMethod({parcelableField1: 1, parcelableField2: "two"});""")
+jsBridge.evaluateUnsync("""$aidlJsValue.aidlMethod({parcelableField1: 1, parcelableField2: "two"});""")
 ```
 
 ### Extensions

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
@@ -44,7 +44,7 @@ public final class JsBridgeJavaTest {
         JsBridge subject = createAndSetUpJsBridge();
 
         // WHEN
-        subject.evaluateNoRetVal("console.log('test message');");
+        subject.evaluateUnsync("console.log('test message');");
     }
 
     @Test

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
@@ -61,10 +61,14 @@ class ReadmeTest {
     @Test
     fun testEvaluation() {
         // Without return value:
-        jsBridge.evaluateNoRetVal("console.log('hello');")
-        jsBridge.evaluateLocalFile(InstrumentationRegistry.getInstrumentation().context, "js/file.js")  // Android asset
+        jsBridge.evaluateUnsync("console.log('hello');")
+        jsBridge.evaluateFileContentUnsync("console.log('hello')", "js/test.js")
 
         runBlocking {
+            // Without return value:
+            jsBridge.evaluate<Unit>("console.log('hello');")
+            jsBridge.evaluateFileContent("console.log('hello')", "js/test.js")
+
             // With return value:
             val sum1: Int = jsBridge.evaluate("1+2")  // suspending call
             val sum2: Int = jsBridge.evaluate("new Promise(function(resolve) { resolve(1+2); })")  // suspending call (JS promise)
@@ -180,7 +184,7 @@ class ReadmeTest {
 
     @Test
     fun testUsageAdvanced() {
-        jsBridge.evaluateLocalFile(InstrumentationRegistry.getInstrumentation().context, "js/api.js")
+        jsBridge.evaluateLocalFileUnsync(InstrumentationRegistry.getInstrumentation().context, "js/api.js")
 
         // Implement native API
         val nativeApi = object: NativeApi {

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
@@ -150,7 +150,7 @@ class ReadmeTest {
 
         val nativeApi: JsValue = JsValue.fromNativeObject(jsBridge, obj)
 
-        jsBridge.evaluateNoRetVal("globalThis.x = $nativeApi.method(1, 'two');")
+        jsBridge.evaluateUnsync("globalThis.x = $nativeApi.method(1, 'two');")
     }
 
     @Test
@@ -167,7 +167,7 @@ class ReadmeTest {
     fun testKotlinFunctionFromJs() {
         val calcSumNative = JsValue.fromNativeFunction2(jsBridge) { a: Int, b: Int -> a + b }
 
-        jsBridge.evaluateNoRetVal("""
+        jsBridge.evaluateUnsync("""
           console.log("Sum is", $calcSumNative(1, 2));
           """.trimIndent())
     }

--- a/jsbridge/src/main/jni/JniInterfaces.cpp
+++ b/jsbridge/src/main/jni/JniInterfaces.cpp
@@ -40,6 +40,11 @@ void JsBridgeInterface::onDebuggerReady() const {
   m_jniCache->getJniContext()->callVoidMethod(m_object, methodId);
 }
 
+JStringLocalRef JsBridgeInterface::callJsModuleLoader(const JStringLocalRef &moduleName) const {
+  static thread_local jmethodID methodId = m_jniCache->getJniContext()->getMethodID(m_class, "callJsModuleLoader", "(Ljava/lang/String;)Ljava/lang/String;");
+  return m_jniCache->getJniContext()->callStringMethod(m_object, methodId, moduleName);
+}
+
 JniLocalRef<jobject> JsBridgeInterface::createJsLambdaProxy(
     const JStringLocalRef &globalName, const JniRef<jsBridgeMethod> &method) const {
 

--- a/jsbridge/src/main/jni/JniInterfaces.h
+++ b/jsbridge/src/main/jni/JniInterfaces.h
@@ -47,6 +47,7 @@ public:
   void checkJsThread() const;
   void onDebuggerPending() const;
   void onDebuggerReady() const;
+  JStringLocalRef callJsModuleLoader(const JStringLocalRef &moduleName) const;
   JniLocalRef<jobject> createJsLambdaProxy(const JStringLocalRef &, const JniRef<jsBridgeMethod> &) const;
   JniLocalRef<jobject> createAidlInterfaceProxy(const JStringLocalRef &, const JniRef<jsBridgeParameter> &) const;
   void consoleLogHelper(const JStringLocalRef &logType, const JStringLocalRef &msg) const;

--- a/jsbridge/src/main/jni/JsBridgeContext.h
+++ b/jsbridge/src/main/jni/JsBridgeContext.h
@@ -55,6 +55,8 @@ public:
   void startDebugger(int port);
   void cancelDebug();
 
+  void enableModuleLoader();
+
   JValue evaluateString(const JStringLocalRef &strSourceCode, const JniLocalRef<jsBridgeParameter> &returnParameter,
                         bool awaitJsPromise) const;
   void evaluateFileContent(const JStringLocalRef &strSourceCode, const std::string &strFileName, bool asModule) const;

--- a/jsbridge/src/main/jni/JsBridgeContext.h
+++ b/jsbridge/src/main/jni/JsBridgeContext.h
@@ -57,7 +57,7 @@ public:
 
   JValue evaluateString(const JStringLocalRef &strSourceCode, const JniLocalRef<jsBridgeParameter> &returnParameter,
                         bool awaitJsPromise) const;
-  void evaluateFileContent(const JStringLocalRef &strSourceCode, const std::string &strFileName) const;
+  void evaluateFileContent(const JStringLocalRef &strSourceCode, const std::string &strFileName, bool asModule) const;
 
   void registerJavaObject(const std::string &strName, const JniLocalRef<jobject> &object,
                                   const JObjectArrayLocalRef &methods);

--- a/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
+++ b/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
@@ -127,6 +127,10 @@ void JsBridgeContext::cancelDebug() {
     duk_trans_socket_finish();
 }
 
+void JsBridgeContext::enableModuleLoader() {
+  throw std::invalid_argument("Cannot use JS module loader on Duktape!");
+}
+
 JValue JsBridgeContext::evaluateString(const JStringLocalRef &strCode, const JniLocalRef<jsBridgeParameter> &returnParameter,
                                        bool awaitJsPromise) const {
   CHECK_STACK(m_ctx);

--- a/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
+++ b/jsbridge/src/main/jni/JsBridgeContext_duktape.cpp
@@ -169,8 +169,7 @@ JValue JsBridgeContext::evaluateString(const JStringLocalRef &strCode, const Jni
   return returnType->pop();
 }
 
-void JsBridgeContext::evaluateFileContent(const JStringLocalRef &strCode, const std::string &strFileName) const {
-
+void JsBridgeContext::evaluateFileContent(const JStringLocalRef &strCode, const std::string &strFileName, bool) const {
   CHECK_STACK(m_ctx);
 
   duk_push_string(m_ctx, strFileName.c_str());

--- a/jsbridge/src/main/jni/JsBridgeContext_quickjs.cpp
+++ b/jsbridge/src/main/jni/JsBridgeContext_quickjs.cpp
@@ -92,7 +92,7 @@ void JsBridgeContext::cancelDebug() {
 
 JValue JsBridgeContext::evaluateString(const JStringLocalRef &strCode, const JniLocalRef<jsBridgeParameter> &returnParameter,
                                        bool awaitJsPromise) const {
-  JSValue v = JS_Eval(m_ctx, strCode.toUtf8Chars(), strCode.utf8Length(), "eval", 0);
+  JSValue v = JS_Eval(m_ctx, strCode.toUtf8Chars(), strCode.utf8Length(), "eval", JS_EVAL_TYPE_GLOBAL);
   JS_AUTORELEASE_VALUE(m_ctx, v);
 
   strCode.releaseChars();  // release chars now as we don't need them anymore
@@ -131,11 +131,12 @@ JValue JsBridgeContext::evaluateString(const JStringLocalRef &strCode, const Jni
   return value;
 }
 
-void JsBridgeContext::evaluateFileContent(const JStringLocalRef &strCode, const std::string &strFileName) const {
-  JSValue v = JS_Eval(m_ctx, strCode.toUtf8Chars(), strCode.utf8Length(), strFileName.c_str(), 0);
-  strCode.releaseChars();  // release chars now as we don't need them anymore
-
+void JsBridgeContext::evaluateFileContent(const JStringLocalRef &strCode, const std::string &strFileName, bool asModule) const {
+  const int flags = asModule ? JS_EVAL_TYPE_MODULE : JS_EVAL_TYPE_GLOBAL;
+  JSValue v = JS_Eval(m_ctx, strCode.toUtf8Chars(), strCode.utf8Length(), strFileName.c_str(), flags);
   JS_AUTORELEASE_VALUE(m_ctx, v);
+
+  strCode.releaseChars();  // release chars now as we don't need them anymore
 
   if (JS_IsException(v)) {
     throw m_exceptionHandler->getCurrentJsException();

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
@@ -118,7 +118,7 @@ JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jn
 }
 
 JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEvaluateFileContent
-    (JNIEnv *env, jobject, jlong lctx, jstring code, jstring filename) {
+    (JNIEnv *env, jobject, jlong lctx, jstring code, jstring filename, jboolean asModule) {
 
   //alog("jniEvaluateFileContent()");
 
@@ -128,7 +128,7 @@ JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEv
   std::string strFilename = JStringLocalRef(jniContext, filename, JniLocalRefMode::Borrowed).toStdString();
 
   try {
-    jsBridgeContext->evaluateFileContent(JStringLocalRef(jniContext, code, JniLocalRefMode::Borrowed), strFilename);
+    jsBridgeContext->evaluateFileContent(JStringLocalRef(jniContext, code, JniLocalRefMode::Borrowed), strFilename, asModule);
   } catch (const std::exception &e) {
     jsBridgeContext->getExceptionHandler()->jniThrow(e);
   }

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.cpp
@@ -95,6 +95,13 @@ JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniDe
   delete jniContext;
 }
 
+JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEnableModuleLoader
+        (JNIEnv *env, jobject, jlong lctx) {
+
+  auto jsBridgeContext = getJsBridgeContext(env, lctx);
+  jsBridgeContext->enableModuleLoader();
+}
+
 JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEvaluateString
     (JNIEnv *env, jobject, jlong lctx, jstring code, jobject returnParameter, jboolean awaitJsPromise) {
 

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
@@ -41,7 +41,7 @@ JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jn
   (JNIEnv *, jobject, jlong, jstring, jobject, jboolean);
 
 JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEvaluateFileContent
-  (JNIEnv *, jobject, jlong, jstring, jstring);
+  (JNIEnv *, jobject, jlong, jstring, jstring, jboolean asModule);
 
 JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniRegisterJavaObject
     (JNIEnv *, jobject, jlong, jstring, jobject, jobjectArray);

--- a/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
+++ b/jsbridge/src/main/jni/de_prosiebensat1digital_oasisjsbridge_JsBridge.h
@@ -37,6 +37,9 @@ JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniCa
 JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniDeleteContext
   (JNIEnv *, jobject, jlong);
 
+JNIEXPORT void JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEnableModuleLoader
+        (JNIEnv *, jobject, jlong);
+
 JNIEXPORT jobject JNICALL Java_de_prosiebensat1digital_oasisjsbridge_JsBridge_jniEvaluateString
   (JNIEnv *, jobject, jlong, jstring, jobject, jboolean);
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -321,8 +321,9 @@ constructor(config: JsBridgeConfig): CoroutineScope {
             evaluateFileContent(content, filename, type)
         }
     }
+
     // Evaluate the given JS code without return value
-    fun evaluateNoRetVal(js: String) {
+    fun evaluateUnsync(js: String) {
         launch {
             val jniJsContext = jniJsContextOrThrow()
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -249,18 +249,26 @@ constructor(config: JsBridgeConfig): CoroutineScope {
         }
     }
 
+    // Defines how the JS file will be interpreted:
+    // - global (default): run the JS code in the global context
+    // - module: run as an ES6 module (QuickJS only, Duktape not supported!)
+    enum class JsFileEvaluationType {
+        Global,
+        Module,
+    }
+
     // Evaluate a local JS file which should be bundled as an asset.
     //
     // If the given file has a corresponding .max file, this one will be used in debug mode.
     // e.g.: "myfile.js" / "myfile.max.js"
-    fun evaluateLocalFile(context: Context, filename: String, useMaxJs: Boolean = false) {
-        launch {
+    suspend fun evaluateLocalFile(context: Context, filename: String, useMaxJs: Boolean = false, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
+        withContext(coroutineContext) {
             val jniJsContext = jniJsContextOrThrow()
 
             try {
                 val (inputStream, jsFileName) = getInputStream(context, filename, useMaxJs)
                 val jsString = inputStream.bufferedReader().use { it.readText() }
-                jniEvaluateFileContent(jniJsContext, jsString, jsFileName)
+                jniEvaluateFileContent(jniJsContext, jsString, jsFileName, type == JsFileEvaluationType.Module)
                 Timber.d("-> $filename ($jsFileName) has been successfully evaluated!")
             } catch (t: Throwable) {
                 throw JsFileEvaluationError(filename, t)
@@ -270,13 +278,27 @@ constructor(config: JsBridgeConfig): CoroutineScope {
         }
     }
 
-    // Evaluate the content of a JavaScript file (e.g. fetched from the network).
-    fun evaluateFileContent(content: String, filename: String) {
+    // Evaluate a local JS file which should be bundled as an asset (blocking version)
+    fun evaluateLocalFileUnsync(context: Context, filename: String, useMaxJs: Boolean = false, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
         launch {
+            evaluateLocalFile(context, filename, useMaxJs, type)
+        }
+    }
+
+    // Evaluate a local JS file which should be bundled as an asset (blocking version)
+    fun evaluateLocalFileBlocking(context: Context, filename: String, useMaxJs: Boolean = false, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
+        runBlocking(coroutineContext) {
+            evaluateLocalFile(context, filename, useMaxJs, type)
+        }
+    }
+
+    // Evaluate the content of a JavaScript file (e.g. fetched from the network).
+    suspend fun evaluateFileContent(content: String, filename: String, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
+        withContext(coroutineContext) {
             val jniJsContext = jniJsContextOrThrow()
 
             try {
-                jniEvaluateFileContent(jniJsContext, content, filename)
+                jniEvaluateFileContent(jniJsContext, content, filename, type == JsFileEvaluationType.Module)
                 Timber.d("-> file content ($filename) has been successfully evaluated!")
             } catch (t: Throwable) {
                 throw JsFileEvaluationError(filename, t)
@@ -286,6 +308,19 @@ constructor(config: JsBridgeConfig): CoroutineScope {
         }
     }
 
+    // Evaluate the content of a JavaScript file (e.g. fetched from the network).
+    fun evaluateFileContentUnsync(content: String, filename: String, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
+        launch {
+            evaluateFileContent(content, filename, type)
+        }
+    }
+
+    // Evaluate the content of a JavaScript file (e.g. fetched from the network).
+    fun evaluateFileContentBlocking(content: String, filename: String, type: JsFileEvaluationType = JsFileEvaluationType.Global) {
+        runBlocking(coroutineContext) {
+            evaluateFileContent(content, filename, type)
+        }
+    }
     // Evaluate the given JS code without return value
     fun evaluateNoRetVal(js: String) {
         launch {
@@ -1049,7 +1084,7 @@ constructor(config: JsBridgeConfig): CoroutineScope {
     private external fun jniCancelDebug(context: Long)
     private external fun jniDeleteContext(context: Long)
     private external fun jniEvaluateString(context: Long, js: String, type: Parameter?, awaitJsPromise: Boolean): Any?
-    private external fun jniEvaluateFileContent(context: Long, js: String, filename: String)
+    private external fun jniEvaluateFileContent(context: Long, js: String, filename: String, asModule: Boolean)
     private external fun jniRegisterJavaLambda(context: Long, name: String, obj: Any, method: Any)
     private external fun jniRegisterJavaObject(context: Long, name: String, obj: Any, methods: Array<Any>)
     private external fun jniRegisterJsObject(context: Long, name: String, methods: Array<out Any>, check: Boolean)

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/PromiseExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/PromiseExtension.kt
@@ -41,10 +41,10 @@ internal class PromiseExtension(
             jsBridge.notifyErrorListeners(e)
         }
 
-        jsBridge.evaluateNoRetVal(promiseJsCode)
+        jsBridge.evaluateUnsync(promiseJsCode)
 
         // Detect unhandled Promise rejections
-        jsBridge.evaluateNoRetVal("""
+        jsBridge.evaluateUnsync("""
             Promise.unhandledRejection = function (args) {
               if (args.event === 'reject') {
                 var value = args.reason;

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
@@ -39,11 +39,11 @@ internal class XMLHttpRequestExtension(
             .assignToGlobal("XMLHttpRequestExtension_send_native")
 
         // Evaluate JS file
-        jsBridge.evaluateNoRetVal(xhrJsCode)
+        jsBridge.evaluateUnsync(xhrJsCode)
     }
 
     fun release() {
-        jsBridge.evaluateNoRetVal("""delete globalThis["XMLHttpRequestExtension_send_native"]""")
+        jsBridge.evaluateUnsync("""delete globalThis["XMLHttpRequestExtension_send_native"]""")
     }
 
     private fun nativeSend(


### PR DESCRIPTION
- Add file evaluation type (global or module) to file evaluation methods
- Add possibility to set a custom ES6 module loader
- Make evaluateLocalFile() and evaluateFileContent() suspending and add "blocking" and "unsync" variants
- Rename evaluateNoRetVal() into evaluateUnsync()
- Small performance improvements and bug fixes