### PR TITLE
Add support for unhandled promise rejections on QuickJS

### DIFF
--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -699,11 +699,6 @@ class JsBridgeTest {
 
     @Test
     fun testUnhandledPromiseRejection() {
-        if (BuildConfig.FLAVOR == "quickjs") {
-            // Not supported (yet) on QuickJS
-            return
-        }
-
         // GIVEN
         val subject = createAndSetUpJsBridge()
 

--- a/jsbridge/src/main/jni/JniInterfaces.cpp
+++ b/jsbridge/src/main/jni/JniInterfaces.cpp
@@ -90,6 +90,12 @@ void JsBridgeInterface::setUpJsPromise(const JStringLocalRef &name, const JniRef
   m_jniCache->getJniContext()->callVoidMethod(m_object, methodId, name, deferred);
 }
 
+void JsBridgeInterface::addUnhandledJsPromiseException(const JValue &exception) const {
+  static thread_local jmethodID methodId = m_jniCache->getJniContext()->getMethodID(
+          m_class, "addUnhandledJsPromiseException", "(L" JSBRIDGE_PKG_PATH "/JsException;)V");
+  m_jniCache->getJniContext()->callVoidMethod(m_object, methodId, exception);
+}
+
 
 // MethodInterface
 // ---

--- a/jsbridge/src/main/jni/JniInterfaces.h
+++ b/jsbridge/src/main/jni/JniInterfaces.h
@@ -54,6 +54,7 @@ public:
   void rejectDeferred(const JniRef<jobject> &javaDeferred, const JValue &exception) const;
   JniLocalRef<jobject> createCompletableDeferred() const;
   void setUpJsPromise(const JStringLocalRef &, const JniRef<jobject> &deferred) const;
+  void addUnhandledJsPromiseException(const JValue &exception) const;
 };
 
 // de.prosiebensat1digital.oasisjsbridge.Method

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -1043,6 +1043,7 @@ class JsBridge
                 // Before completing the promise, we want to ensure that pending operations
                 // which has just been triggered (e.g. assigning a JsValue) can be done in the
                 // JS thread before.
+		yield()
 
                 isFulfilled = true
                 result
@@ -1054,6 +1055,12 @@ class JsBridge
             jniCompleteJsPromise(jniJsContext, id, isFulfilled, promiseValue)
             processPromiseQueue()
         }
+    }
+
+    @Suppress("UNUSED")  // Called from JNI
+    private fun addUnhandledJsPromiseException(exception: JsException) {
+        val e = UnhandledJsPromiseError(exception)
+        notifyErrorListeners(e)
     }
 
     private fun launchInJsThread(block: suspend () -> Unit) {


### PR DESCRIPTION
Note: support for Duktape was already available