### PR TITLE
Support empty body PUT in XHR

### DIFF
--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -2515,6 +2515,71 @@ class JsBridgeTest {
     }
 
     @Test
+    fun testXmlHttpEmptyBodyPutRequest() {
+        // GIVEN
+        val subject = createAndSetUpJsBridge()
+
+        val url = "https://test.url/api/request"
+        val requestHeaders = hashMapOf("testRequestHeaderKey1" to "testRequestHeaderValue1", "testRequestHeaderKey2" to "testRequestHeaderValue2")
+        val responseText = """{"testKey1": "testValue1", "testKey2": "testValue2"}"""
+        val responseHeaders = """{"testResponseHeaderKey1": "testResponseHeaderValue1", "testResponseHeaderKey2": "testResponseHeaderValue2"}"""
+        httpInterceptor.mockRequest(url, responseText, responseHeaders)
+
+        // WHEN
+        val js = """
+            |var xhr = new XMLHttpRequest();
+            |${requestHeaders.map {
+            """xhr.setRequestHeader("${it.key}", "${it.value}");"""
+        }.joinToString("\n")}
+            |xhr.responseType = "json";
+            |xhr.open("PUT", "$url");
+            |xhr.send();
+            |xhr.onload = function() {
+            |  // Convert XHR headers value into JSON (see https://stackoverflow.com/a/37934624/9947065)
+            |  var headers = xhr.getAllResponseHeaders().split('\r\n').reduce(function (acc, current, i) {
+            |    var parts = current.split(new RegExp(' *: *'));
+            |    if (parts.length === 2) acc[parts[0]] = parts[1];
+            |    return acc;
+            |  }, {});
+            |  javaFunctionMock(JSON.stringify(xhr.response));
+            |  javaFunctionMock(JSON.stringify(headers));
+            |}""".trimMargin()
+        subject.evaluateUnsync(js)
+
+        // THEN
+        // Note: mock verify with ordering currently has some issues on API < 24
+        if (android.os.Build.VERSION.SDK_INT >= 24) {
+            verify(timeout = 2000, ordering = Ordering.SEQUENCE) {
+                jsToJavaFunctionMock(match { responseJson ->
+                    assertNotNull(responseJson)
+                    val responseObject = PayloadObject.fromJsonString(responseJson as String)
+                    assertNotNull(responseObject)
+                    assertEquals(2, responseObject.keyCount)
+                    assertEquals("testValue1", responseObject.getString("testKey1"))
+                    assertEquals("testValue2", responseObject.getString("testKey2"))
+                    true
+                })
+
+                jsToJavaFunctionMock(match { headersJson ->
+                    val responseHeadersObject = PayloadObject.fromJsonString(headersJson as String)
+                    assertNotNull(responseHeadersObject)
+                    assertEquals(2, responseHeadersObject.keyCount)
+                    assertEquals(
+                        "testResponseHeaderValue1",
+                        responseHeadersObject.getString("testresponseheaderkey1")
+                    )
+                    assertEquals(
+                        "testResponseHeaderValue2",
+                        responseHeadersObject.getString("testresponseheaderkey2")
+                    )
+                    true
+                })
+            }
+        }
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
     fun testXmlHttpRequest_abort() {
         // GIVEN
         val subject = createAndSetUpJsBridge()

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
@@ -93,11 +93,11 @@ internal class XMLHttpRequestExtension(
                 // Request body
                 val contentType = requestHeaders["content-type"] ?: ""
                 val requestBody = when {
-                    /* in specific case when we want to send an empty post request,
+                    /* in specific case when we want to send an empty post/put request,
                      we should instead send request with body with no data.
                      Otherwise, OkHttp will throw an exception:
-                     "Method post must have a request body */
-                    data == null && httpMethod.lowercase(Locale.ROOT) == "post" -> {
+                     "Method post/put must have a request body */
+                    data == null && httpMethod.lowercase(Locale.ROOT) in listOf("post", "put") -> {
                         "".toRequestBody(contentType.toMediaTypeOrNull())
                     }
                     else -> {


### PR DESCRIPTION
Similarly to what was done on https://github.com/p7s1digital/oasis-jsbridge-android/pull/20, `PUT` can also be used with no body, so we could send an empty one so OkHttp doesn't complain.

Copy/pasted the same unit test already done for `POST` and changed it for `PUT`.