### PR TITLE
Delete XHR request headers on open

### DIFF
--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/XMLHttpRequestExtension.kt
@@ -266,6 +266,8 @@ XMLHttpRequest.prototype.constructor = XMLHttpRequest;
 XMLHttpRequest.prototype.open = function(httpMethod, url) {
   this._httpMethod = httpMethod;
   this._url = url;
+  
+  this._requestHeaders = [];
 
   this.readyState = XMLHttpRequest.OPENED;
   if (typeof this.onreadystatechange === "function") {


### PR DESCRIPTION
Related with #44.

According to XHR spec (https://xhr.spec.whatwg.org/#the-open()-method), `open` should remove all previously set request headers.