### PR TITLE
Backport of local storage namespace feature with an option to disable namespaces for backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Evaluate JavaScript code and map values, objects and functions between Kotlin/Java and JavaScript on Android.
 
 ```kotlin
-val jsBridge = JsBridge(JsBridgeConfig.bareConfig())
+val jsBridge = JsBridge(JsBridgeConfig.bareConfig(), context, "namespace")
 val msg: String = jsBridge.evaluate("'Hello world!'.toUpperCase()")
 println(msg)  // HELLO WORLD!
 ```
@@ -304,6 +304,9 @@ Other network clients are not tested but should work as well (polyfill for
 Support for ES6 promises (Duktape: via polyfill, QuickJS: built-in). Pending jobs are triggered
 after each evaluation.
 
+- **LocalStorage:**<br/>
+Support for browser-like local storage.
+
 - **JS Debugger:**<br/>
 JS debugger support (Duktape only via Visual Studio Code plugin)
 
@@ -401,7 +404,7 @@ val nativeApi = object: NativeApi {
 
 Bridging JavaScript and Kotlin:
 ```kotlin
-val jsBridge = JsBridge(JsBridgeConfig.standardConfig())
+val jsBridge = JsBridge(JsBridgeConfig.standardConfig(), context, "namespace")
 jsBridge.evaluateLocalFileUnsync(context, "js/api.js")
 
 // JS "proxy" to native API

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
@@ -153,7 +153,7 @@ public final class JsBridgeJavaTest {
     // ---
 
     private JsBridge createAndSetUpJsBridge() {
-        JsBridge jsBridge = new JsBridge(JsBridgeConfig.standardConfig(), context);
+        JsBridge jsBridge = new JsBridge(JsBridgeConfig.standardConfig(), context, "test_namespace");
         this.jsBridge = jsBridge;
         return jsBridge;
     }

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
@@ -39,7 +39,7 @@ class ReadmeTest {
 
     @Before
     fun setUp() {
-        jsBridge = JsBridge(JsBridgeConfig.standardConfig(), context)
+        jsBridge = JsBridge(JsBridgeConfig.standardConfig(), context,"test_namespace")
     }
 
     @After

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -57,9 +57,13 @@ import java.lang.reflect.Proxy
  * Note: all the public methods are asynchronous and will not block the caller threads. They
  * can be safely called in a "synchronous" way. though, because their executions are guaranteed
  * to be performed sequentially (via an internal queue).
+ *
+ * @param config JsBridge configuration
+ * @param context Context needed for built in implementation of local storage
+ * @param namespace arbitrary string for separation of local storage between multiple JsBridge instances
  */
 class JsBridge
-    constructor(config: JsBridgeConfig, context: Context) : CoroutineScope {
+    constructor(config: JsBridgeConfig, context: Context, namespace: String) : CoroutineScope {
 
     companion object {
         private var isLibraryLoaded = false
@@ -158,7 +162,7 @@ class JsBridge
             if (config.xhrConfig.enabled)
                 xhrExtension = XMLHttpRequestExtension(this@JsBridge, config.xhrConfig)
             if (config.localStorageConfig.enabled)
-                localStorageExtension = LocalStorageExtension(this@JsBridge, config.localStorageConfig, context.applicationContext)
+                localStorageExtension = LocalStorageExtension(this@JsBridge, config.localStorageConfig, context.applicationContext, namespace)
             config.jvmConfig.customClassLoader?.let { customClassLoader = it }
         }
     }

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
@@ -62,6 +62,16 @@ private constructor() {
     class LocalStorageConfig {
         var enabled: Boolean = false
         var useDefaultLocalStorage: Boolean = true
+
+        /**
+         * Only disable namespaces if a particular instance of JsBridge requires access to local
+         * storage key/value pairs that were saved with a previous version of the library.
+         *
+         * You should try to avoid using multiple unrelated instances of JsBridge without namespaces
+         * or with an identical namespace. An exception would be if you want to explicitly share data
+         * between instances and the possibility of key name collisions is not an issue.
+         */
+        var useNamespaces: Boolean = true
     }
 
     class JvmConfig {

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
@@ -13,10 +13,11 @@ interface LocalStorageInteface : JsToNativeInterface {
     fun clear()
 }
 
-class LocalStorage(context: Context, namespace: String) : LocalStorageInteface {
+class LocalStorage(context: Context, namespace: String?) : LocalStorageInteface {
 
     private val localStoragePreferences = context.getSharedPreferences(
-        "${namespace.takeIf { it.isNotEmpty() } ?: "default"}.LOCAL_STORAGE_PREFERENCES",
+        namespace?.let { "${it.takeIf { it.isNotEmpty() } ?: "default"}.LOCAL_STORAGE_PREFERENCES" }
+            ?: "${context.applicationInfo.packageName}.LOCAL_STORAGE_PREFERENCE_FILE_KEY",
         Context.MODE_PRIVATE
     )
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
@@ -13,10 +13,10 @@ interface LocalStorageInteface : JsToNativeInterface {
     fun clear()
 }
 
-class LocalStorage(context: Context) : LocalStorageInteface {
+class LocalStorage(context: Context, namespace: String) : LocalStorageInteface {
 
     private val localStoragePreferences = context.getSharedPreferences(
-        context.applicationInfo.packageName + ".LOCAL_STORAGE_PREFERENCE_FILE_KEY",
+        "${namespace.takeIf { it.isNotEmpty() } ?: "default"}.LOCAL_STORAGE_PREFERENCES",
         Context.MODE_PRIVATE
     )
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
@@ -29,7 +29,7 @@ internal class LocalStorageExtension(
 
     init {
         if (config.useDefaultLocalStorage) {
-            val localStorage: LocalStorageInteface = LocalStorage(context, namespace)
+            val localStorage: LocalStorageInteface = LocalStorage(context, namespace.takeIf { config.useNamespaces })
             val localStorageJsValue = JsValue.fromNativeObject(jsBridge, localStorage)
             localStorageJsValue.assignToGlobal("localStorage")
         }

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
@@ -21,16 +21,16 @@ import de.prosiebensat1digital.oasisjsbridge.JsBridgeConfig
 import de.prosiebensat1digital.oasisjsbridge.JsValue
 
 internal class LocalStorageExtension(
-    private val jsBridge: JsBridge,
-    val config: JsBridgeConfig.LocalStorageConfig,
+    jsBridge: JsBridge,
+    config: JsBridgeConfig.LocalStorageConfig,
     context: Context,
+    namespace: String,
 ) {
 
     init {
         if (config.useDefaultLocalStorage) {
-            val localStorageJsValue: JsValue
-            val localStorage: LocalStorageInteface = LocalStorage(context)
-            localStorageJsValue = JsValue.fromNativeObject(jsBridge, localStorage)
+            val localStorage: LocalStorageInteface = LocalStorage(context, namespace)
+            val localStorageJsValue = JsValue.fromNativeObject(jsBridge, localStorage)
             localStorageJsValue.assignToGlobal("localStorage")
         }
     }


### PR DESCRIPTION
As there is no stable release 1.0.0 available yet, we decided to backport the namespace feature to the latest non alpha release.

We also added an option to disable the namespace feature if applications decide they want to keep using the old legacy file name for the SharedPreferences backing local storage. This could be important if previously saved data is essential and needs to survive an update. All newly created instances of JsBridge used for unrelated features should use namespaces to avoid collisions.
