### PR TITLE
Local storage cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Evaluate JavaScript code and map values, objects and functions between Kotlin/Java and JavaScript on Android.
 
 ```kotlin
-val jsBridge = JsBridge(JsBridgeConfig.bareConfig(), context, "namespace")
+val jsBridge = JsBridge(JsBridgeConfig.bareConfig(), context)
 val msg: String = jsBridge.evaluate("'Hello world!'.toUpperCase()")
 println(msg)  // HELLO WORLD!
 ```
@@ -300,14 +300,16 @@ Support for ES6 promises (Duktape: via polyfill, QuickJS: built-in). Pending job
 after each evaluation.
 
 - **LocalStorage:**<br/>
-Support for browser-like local storage.
+Built-in support for browser-like local storage. Use `JsBridgeConfig.standardConfig(namespace)`
+to initialise the local storage extension using a namespace for separation of saved data between
+multiple JsBridge instances.
+_Note: If you use your own implementation of local storage you should disable this extension! 
 
 - **JS Debugger:**<br/>
 JS debugger support (Duktape only via Visual Studio Code plugin)
 
 - **JVM config:**<br/>
 Offers the possibility to set a custom class loader which will be used by the JsBridge to find classes.
-
 
 ## Supported types
 
@@ -404,7 +406,7 @@ val javaApi = object: JavaApi {
 
 Bridging JavaScript and Kotlin:
 ```kotlin
-val jsBridge = JsBridge(JsBridgeConfig.standardConfig(), context, "namespace")
+val jsBridge = JsBridge(JsBridgeConfig.standardConfig("namespace"), context)
 jsBridge.evaluateLocalFile(context, "js/api.js")
 
 // JS "proxy" to Java API

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeJavaTest.java
@@ -123,7 +123,7 @@ public final class JsBridgeJavaTest {
     // ---
 
     private JsBridge createAndSetUpJsBridge() {
-        JsBridge jsBridge = new JsBridge(JsBridgeConfig.standardConfig(), context, "test_namespace");
+        JsBridge jsBridge = new JsBridge(JsBridgeConfig.standardConfig("test_namespace"), context);
         this.jsBridge = jsBridge;
         return jsBridge;
     }

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -2851,7 +2851,7 @@ class JsBridgeTest {
 
         // GIVEN
         val subjectNoLocalStorage = createAndSetUpJsBridge(JsBridgeConfig.standardConfig().apply {
-            localStorageConfig.useDefaultLocalStorage = false
+            localStorageConfig.enabled = false
         })
 
         // WHEN

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeTest.kt
@@ -1235,10 +1235,10 @@ class JsBridgeTest {
     }
 
     private fun stressTestHelper() {
-        val config = JsBridgeConfig.standardConfig().apply {
+        val config = JsBridgeConfig.standardConfig(NAMESPACE).apply {
             xhrConfig.okHttpClient = okHttpClient
         }
-        val subject = JsBridge(config, context, NAMESPACE)
+        val subject = JsBridge(config, context)
 
         val jsExpectations = JsExpectations()
         val jsExpectationsJsValue = JsValue.createJsToJavaProxy(subject, jsExpectations)
@@ -1606,10 +1606,10 @@ class JsBridgeTest {
             }
         }
 
-        val config = JsBridgeConfig.standardConfig().apply {
+        val config = JsBridgeConfig.standardConfig(NAMESPACE).apply {
             xhrConfig.okHttpClient = okHttpClient
         }
-        val subject = JsBridge(config, context, NAMESPACE)
+        val subject = JsBridge(config, context)
 
         val jsExpectations = JsExpectations()
         val jsExpectationsJsValue = JsValue.createJsToJavaProxy(subject, jsExpectations)
@@ -2739,7 +2739,7 @@ class JsBridgeTest {
                 messages.add(priority to message)
             }
         }
-        val subject = JsBridge(config, context, NAMESPACE)
+        val subject = JsBridge(config, context)
         jsBridge = subject
 
         // WHEN
@@ -2777,7 +2777,7 @@ class JsBridgeTest {
                 messages.add(priority to message)
             }
         }
-        val subject = JsBridge(config, context, NAMESPACE)
+        val subject = JsBridge(config, context)
         jsBridge = subject
 
         // WHEN
@@ -2815,7 +2815,7 @@ class JsBridgeTest {
                 hasMessage = true
             }
         }
-        val subject = JsBridge(config, context, NAMESPACE)
+        val subject = JsBridge(config, context)
         jsBridge = subject
 
         // WHEN
@@ -2850,7 +2850,7 @@ class JsBridgeTest {
         assertTrue(errors.isEmpty())
 
         // GIVEN
-        val subjectNoLocalStorage = createAndSetUpJsBridge(JsBridgeConfig.standardConfig().apply {
+        val subjectNoLocalStorage = createAndSetUpJsBridge(JsBridgeConfig.standardConfig(NAMESPACE).apply {
             localStorageConfig.enabled = false
         })
 
@@ -2866,7 +2866,9 @@ class JsBridgeTest {
     fun testLocalStorageNamespaces() {
         // GIVEN
         val subject1 = createAndSetUpJsBridge()
-        val subject2 = createAndSetUpJsBridge(namespace = "other_namespace")
+        val subject2 = createAndSetUpJsBridge(config = JsBridgeConfig.standardConfig("other_namespace").apply {
+            xhrConfig.okHttpClient = okHttpClient
+        },)
 
         // WHEN
         subject1.evaluateBlocking<Unit>("""localStorage.setItem("key", "value");""")
@@ -3021,13 +3023,12 @@ class JsBridgeTest {
     // ---
 
     private fun createAndSetUpJsBridge(
-        config: JsBridgeConfig = JsBridgeConfig.standardConfig().apply {
+        config: JsBridgeConfig = JsBridgeConfig.standardConfig(NAMESPACE).apply {
             xhrConfig.okHttpClient = okHttpClient
         },
-        namespace: String = NAMESPACE,
     ): JsBridge {
 
-        return JsBridge(config, context, namespace).also { jsBridge ->
+        return JsBridge(config, context).also { jsBridge ->
             this@JsBridgeTest.jsBridge = jsBridge
 
             jsBridge.registerErrorListener(createErrorListener())

--- a/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
+++ b/jsbridge/src/androidTest/kotlin/de/prosiebensat1digital/oasisjsbridge/ReadmeTest.kt
@@ -39,7 +39,7 @@ class ReadmeTest {
 
     @Before
     fun setUp() {
-        jsBridge = JsBridge(JsBridgeConfig.standardConfig(), context,"test_namespace")
+        jsBridge = JsBridge(JsBridgeConfig.standardConfig("test_namespace"), context)
     }
 
     @After

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridge.kt
@@ -58,11 +58,10 @@ import java.lang.reflect.Proxy
  * to be performed sequentially (via an internal queue).
  *
  * @param config JsBridge configuration
- * @param context Context needed for built in implementation of local storage
- * @param namespace arbitrary string for separation of local storage between multiple JsBridge instances
+ * @param context Context needed for local storage extension
  */
 class JsBridge
-    constructor(config: JsBridgeConfig, context: Context, namespace: String) : CoroutineScope {
+    constructor(config: JsBridgeConfig, context: Context) : CoroutineScope {
 
     companion object {
         private var isLibraryLoaded = false
@@ -161,7 +160,7 @@ class JsBridge
             if (config.xhrConfig.enabled)
                 xhrExtension = XMLHttpRequestExtension(this@JsBridge, config.xhrConfig)
             if (config.localStorageConfig.enabled)
-                localStorageExtension = LocalStorageExtension(this@JsBridge, config.localStorageConfig, context.applicationContext, namespace)
+                localStorageExtension = LocalStorageExtension(this@JsBridge, config.localStorageConfig, context.applicationContext)
             config.jvmConfig.customClassLoader?.let { customClassLoader = it }
         }
     }

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
@@ -6,16 +6,28 @@ import okhttp3.OkHttpClient
 class JsBridgeConfig
 private constructor() {
     companion object {
+        /**
+         * Creates an instance of JsBridgeConfig without any extensions.
+         */
         @JvmStatic
         fun bareConfig() = JsBridgeConfig()
 
+        /**
+         * Creates an instance of JsBridgeConfig and enables all extensions.
+         * @param localStorageNamespace arbitrary string for separation of local storage between
+         * multiple JsBridge instances. If you use the same namespace for multiple instances of
+         * JsBridge there might be collisions if identical keys are used to store values.
+         */
         @JvmStatic
-        fun standardConfig() = JsBridgeConfig().apply {
+        fun standardConfig(localStorageNamespace: String) = JsBridgeConfig().apply {
             setTimeoutConfig.enabled = true
             xhrConfig.enabled = true
             promiseConfig.enabled = true
             consoleConfig.enabled = true
-            localStorageConfig.enabled = true
+            localStorageConfig.apply {
+                enabled = true
+                namespace = localStorageNamespace
+            }
         }
     }
 
@@ -62,15 +74,7 @@ private constructor() {
     class LocalStorageConfig {
         var enabled: Boolean = false
 
-        /**
-         * Only disable namespaces if a particular instance of JsBridge requires access to local
-         * storage key/value pairs that were saved with a previous version of the library.
-         *
-         * You should try to avoid using multiple unrelated instances of JsBridge without namespaces
-         * or with an identical namespace. An exception would be if you want to explicitly share data
-         * between instances and the possibility of key name collisions is not an issue.
-         */
-        var useNamespaces: Boolean = true
+        var namespace: String = ""
     }
 
     class JvmConfig {

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsBridgeConfig.kt
@@ -61,7 +61,6 @@ private constructor() {
 
     class LocalStorageConfig {
         var enabled: Boolean = false
-        var useDefaultLocalStorage: Boolean = true
 
         /**
          * Only disable namespaces if a particular instance of JsBridge requires access to local

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorage.kt
@@ -13,11 +13,10 @@ interface LocalStorageInteface : JsToJavaInterface {
     fun clear()
 }
 
-class LocalStorage(context: Context, namespace: String?) : LocalStorageInteface {
+class LocalStorage(context: Context, namespace: String) : LocalStorageInteface {
 
     private val localStoragePreferences = context.getSharedPreferences(
-        namespace?.let { "${it.takeIf { it.isNotEmpty() } ?: "default"}.LOCAL_STORAGE_PREFERENCES" }
-            ?: "${context.applicationInfo.packageName}.LOCAL_STORAGE_PREFERENCE_FILE_KEY",
+        "${namespace.takeIf { it.isNotEmpty() } ?: "default"}.LOCAL_STORAGE_PREFERENCES",
         Context.MODE_PRIVATE
     )
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
@@ -28,11 +28,9 @@ internal class LocalStorageExtension(
 ) {
 
     init {
-        if (config.useDefaultLocalStorage) {
-            val localStorage: LocalStorageInteface = LocalStorage(context, namespace.takeIf { config.useNamespaces })
-            val localStorageJsValue = JsValue.createJsToJavaProxy(jsBridge, localStorage)
-            localStorageJsValue.assignToGlobal("localStorage")
-        }
+        val localStorage: LocalStorageInteface = LocalStorage(context, namespace.takeIf { config.useNamespaces })
+        val localStorageJsValue = JsValue.createJsToJavaProxy(jsBridge, localStorage)
+        localStorageJsValue.assignToGlobal("localStorage")
     }
 }
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/extensions/LocalStorageExtension.kt
@@ -24,11 +24,10 @@ internal class LocalStorageExtension(
     jsBridge: JsBridge,
     config: JsBridgeConfig.LocalStorageConfig,
     context: Context,
-    namespace: String,
 ) {
 
     init {
-        val localStorage: LocalStorageInteface = LocalStorage(context, namespace.takeIf { config.useNamespaces })
+        val localStorage: LocalStorageInteface = LocalStorage(context, config.namespace)
         val localStorageJsValue = JsValue.createJsToJavaProxy(jsBridge, localStorage)
         localStorageJsValue.assignToGlobal("localStorage")
     }


### PR DESCRIPTION
We moved the `namespace` argument from `JsBridge` to the configuration to give implementers the possibility to initialize a bare instance if they don't need the extension.

Redundant config options were also removed.