### PR TITLE
Prevent json object string from being 'escaped' again in the library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 
         kotlin: [
             coroutines: '1.6.4',
+            serialization: '1.5.0',
             kotlin: '1.7.22',
         ],
 
@@ -34,6 +35,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin.kotlin"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$versions.kotlin.kotlin"
     }
 }
 

--- a/jsbridge/build.gradle
+++ b/jsbridge/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 
 apply from: "${rootDir}/scripts/javadoc.gradle"
 apply from: "${rootDir}/scripts/publishing.gradle"
@@ -135,6 +136,7 @@ dependencies {
 
     androidTestImplementation "junit:junit:$versions.junit"
 
+    testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$versions.kotlin.serialization"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$versions.kotlin.kotlin"
     testImplementation "io.mockk:mockk:$versions.mockk"
 

--- a/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsonObjectWrapper.kt
+++ b/jsbridge/src/main/kotlin/de/prosiebensat1digital/oasisjsbridge/JsonObjectWrapper.kt
@@ -119,6 +119,10 @@ open class JsonObjectWrapper(val jsonString: String) {
         }
 
         private fun escape(string: String): String {
+            // if its a JSON string starting with '{' && ends with '}' then return same string as we don't want to escape any characters in this case
+            if (string.isNotEmpty() && string.startsWith("{") && string.endsWith("}")) {
+                return string
+            }
             val builder = StringBuilder()
             builder.append('"')
             string.forEach { char ->
@@ -142,8 +146,9 @@ open class JsonObjectWrapper(val jsonString: String) {
         }
         val builder = StringBuilder()
         builder.append("JSON.parse(\"")
-        jsonString.forEach { char ->
+        jsonString.forEachIndexed { index, char ->
             when (char) {
+                '\\' -> if (jsonString.getOrNull(index + 1) == '"') builder.append("") // if already escaped then eat it
                 '"' -> builder.append("\\\"")
                 '\n' -> builder.append(" ")
                 else -> builder.append(char)


### PR DESCRIPTION
Creating jsonObjects using "buildJsonObject" KotlinX Serialization API automatically escapes characters ('\')  inside json strings. To prevent escaping happening twice, we need to prevent json object strings being 'escaped' again in the library. Added unit test for such case and adjusted existing ones.